### PR TITLE
Add new workflow to build image and push resulting OSTree

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,117 @@
+name: Yocto build and OSTree push
+
+on:
+    workflow_dispatch:
+        inputs:
+            machine:
+                description: "Hardware machine"
+                required: true
+                type: choice
+                options:
+                    - apalis-imx6
+                    - apalis-imx8
+                    - beaglebone-yocto
+                    - beagleplay
+                    - colibri-imx6
+                    - colibri-imx6ull-emmc
+                    - colibri-imx7-emmc
+                    - colibri-imx8x
+                    - genericx86-64
+                    - intel-corei7-64
+                    - nezha-allwinner-d1
+                    - qemuarm64
+                    - qemux86-64
+                    - raspberrypi0-2w-64
+                    - raspberrypi0-wifi
+                    - raspberrypi3-64
+                    - raspberrypi4-64
+                    - verdin-am62
+                    - verdin-imx8mm
+                    - verdin-imx8mp
+            branch:
+                description: "Manifest repo branch to use"
+                required: true
+                type: choice
+                options:
+                    - kirkstone
+                    - master
+                    - nanbield
+            manifest:
+                description: "Manifest file to use"
+                required: true
+                type: choice
+                options:
+                    - common.xml
+                    - default.xml
+                    - integration.xml
+                    - next.xml
+
+env:
+  BUCKET_NAME: "s3://commontorizon/ostree-repo/"
+  AWS_REGION: "eu-central-1"
+  MACHINE: "${{ inputs.machine }}"
+  BRANCH: "${{ inputs.branch }}"
+  MANIFEST: "${{ inputs.manifest }}"
+  MASTER_REPO: "/ostree"
+
+permissions:
+    id-token: write   # This is required for requesting the JWT
+    contents: read    # This is required for actions/checkout
+
+jobs:
+  build-yocto:
+    runs-on: [self-hosted, linux, x64, yocto]
+    steps:
+    - name: Build Yocto image
+      working-directory: /workdir
+      run: |
+        rm -rf * .repo
+        repo init -u https://github.com/commontorizon/commontorizon-manifest.git -b ${{ env.BRANCH }} -m torizoncore/${{ env.MANIFEST }}
+        repo sync
+        MACHINE=${{ env.MACHINE }} EULA=1 source setup-environment
+        grep -qxF 'TDX_PURPOSE = "Release"' conf/local.conf || echo 'TDX_PURPOSE = "Release"' >> conf/local.conf
+        bitbake torizon-core-docker
+    - name: Create tar archive of artifacts
+      run: |
+        tar -cvf ${{ env.MACHINE }}-artifacts.tar -C /workdir/build-*/deploy/images/${{ env.MACHINE }}/ .
+    - name: Upload Yocto artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.MACHINE }}-artifacts
+        path: ${{ env.MACHINE }}-artifacts.tar
+
+  ostree-push:
+    runs-on: [self-hosted, linux, x64, yocto]
+    needs: build-yocto
+    steps:
+    - name: Cleanup workspace
+      run: |
+        rm -rf ${{ github.workspace }}/*
+    - name: Download Yocto artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.MACHINE }}-artifacts
+    - name: Unpack artifacts
+      run: |
+        tar xf ${{ env.MACHINE }}-artifacts.tar
+    - name: Evaluate OSTree ref
+      run: |
+        echo "REF=$(ostree refs --repo ostree_repo)" >> "$GITHUB_ENV"
+    - name: Evaluate OSTree commit
+      run: |
+        echo "COMMIT=$(ostree rev-parse $REF --repo ostree_repo)" >> "$GITHUB_ENV"
+    - name: Promote OSTree
+      run: |
+        ostree-repo-promotion.py --srcRepo ostree_repo --targetRepo ${{ env.MASTER_REPO }} --ref $REF --commit $COMMIT
+    - name: Configure aws credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::590183833123:role/CommonTorizonOstreePushToS3
+        role-session-name: CommonTorizonOSTreePushSession
+        aws-region: ${{ env.AWS_REGION }}
+    - name: Sync Master OSTree to S3
+      run: |
+        ostree summary -u --repo ${{ env.MASTER_REPO}}
+        aws s3 sync ${{ env.MASTER_REPO }} ${{ env.BUCKET_NAME }} --exclude='*' --include='objects/*' --include='deltas/*' --size-only
+        aws s3 sync ${{ env.MASTER_REPO }} ${{ env.BUCKET_NAME }} --exclude='*' --include='refs/*' --include='summar*' --include 'config*' --delete
+        aws s3 sync ${{ env.MASTER_REPO }} ${{ env.BUCKET_NAME }} --exclude='*' --include='objects/*' --include='deltas/*' --size-only --delete


### PR DESCRIPTION
This new workflow does a yocto build for the machine of choice. If succesful it uploads the build artifacts to Github. It finally uploads the OSTree repo files from the build to an AWS S3 bucket.